### PR TITLE
Migrate from Heroku to Fly.io + Neon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.env
+.env.*
+.git
+.github
+.vscode
+.claude
+.DS_Store
+yarn-error.log
+*.md
+!README.md
+Procfile

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
 DISCORD_CLIENT_ID=
 DISCORD_TOKEN=
-DATABASE_URL=
+
+# For local development, start Postgres with `docker compose up -d` and use:
+DATABASE_URL=postgresql://dev:dev@localhost:5433/letterboxd_bot

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to Fly
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 - `yarn dev` — run the bot locally with hot reload (nodemon + ts-node, watches `src/**/*.ts`).
-- `yarn start` — production entry; runs `prisma migrate deploy`, `prisma generate`, then `ts-node src/app.ts`. Used by the Heroku `worker` process (`Procfile`).
+- `yarn start` — production entry; runs `prisma migrate deploy`, `prisma generate`, then `ts-node src/app.ts`. Used as the container `CMD` in the included `Dockerfile`.
 - `yarn db:migrate` — `prisma migrate dev` against `DATABASE_URL`.
 - `yarn db:generate` — regenerate the Prisma client (run after editing `prisma/schema.prisma`).
 - `yarn deploy-commands` — script entry to push slash command definitions; note that in normal operation `app.ts` already deploys commands to every guild on `ready` and on `guildCreate`, so manual invocation is rarely needed.
@@ -13,7 +13,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Required env vars (`.env`, see `.env.sample`): `DISCORD_CLIENT_ID`, `DISCORD_TOKEN`, `DATABASE_URL` (Postgres). `ENV=dev` is read in `lib/deploy-commands.ts` but currently no-op.
 
-Node 18 (see `engines` in `package.json`). The README still says Node 16 — `package.json` is authoritative.
+Node 24 (see `engines` in `package.json` and `.nvmrc`).
+
+**Deployment:** the repo ships a `Dockerfile` and a `fly.toml` configured as a worker (no HTTP service). `.github/workflows/deploy.yml` deploys to Fly on push to `main` via the `FLY_API_TOKEN` secret. Postgres is expected to be external (Neon recommended); set `DATABASE_URL` via `fly secrets set`.
 
 ## Architecture
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:24-slim
+
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY prisma ./prisma
+RUN yarn db:generate
+
+COPY . .
+
+CMD ["yarn", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-worker: yarn start

--- a/README.md
+++ b/README.md
@@ -39,27 +39,67 @@ nvm install 24
 nvm use 24
 ```
 
-Create an `.env` from the sample file and input your Discord credentials and local Redis server URL
+Create an `.env` from the sample file and fill in your Discord credentials.
 ```sh
 cp .env.sample .env
 ```
 
-Data for this bot is stored in Postgresql and uses Prisma as the ORM. Make sure you have a Postgres server running and set the `DATABASE_URL` in your env.
+Data is stored in Postgres via Prisma. The repo includes a `docker-compose.yml` for local development — start it with:
+
+```sh
+docker compose up -d
+```
+
+This runs Postgres 17 on `localhost:5432` with the credentials already wired into `.env.sample`. To stop it: `docker compose down`. Data persists in a Docker volume between restarts.
+
+If you'd rather use a Postgres install of your own, just update `DATABASE_URL` in `.env`.
 
 ### Development
-Install latest dependencies
+
+Install dependencies once:
 ```
 yarn install
 ```
 
-Run any pending database migrations
-
-```
-yarn db:migrate
-```
-
-And finally start the dev server
+Then bring up the whole dev environment with one command:
 ```sh
-# Suports hot reloading
-yarn dev
+yarn up
 ```
+
+This starts the local Postgres container (waits for it to be healthy), applies any pending migrations, and runs the bot with hot reload.
+
+If you'd rather run the pieces separately:
+```sh
+docker compose up -d   # start Postgres
+yarn db:migrate        # apply migrations
+yarn dev               # run the bot
+```
+
+## Deployment
+
+The bot is a long-running worker (Discord gateway + a 1-minute cron loop). It needs an always-on host plus a Postgres database. A `Dockerfile` is included so you can deploy to any container platform.
+
+### Recommended: Fly.io + Neon (~$0–5/mo)
+
+1. **Create a Postgres database on [Neon](https://neon.tech)** and copy the connection string.
+2. **Install [`flyctl`](https://fly.io/docs/flyctl/install/)** and run `fly launch --no-deploy --copy-config` from the repo root. If the app name `letterboxd-discord-bot` is taken, Fly will prompt you for a different one — update `fly.toml` to match.
+3. **Set secrets:**
+   ```sh
+   fly secrets set \
+     DISCORD_CLIENT_ID=... \
+     DISCORD_TOKEN=... \
+     DATABASE_URL='postgresql://...neon.tech/...?sslmode=require'
+   ```
+4. **Deploy:** `fly deploy`
+
+### Auto-deploy via GitHub Actions
+
+A workflow at `.github/workflows/deploy.yml` deploys to Fly on every push to `main`. To use it on your fork:
+
+1. Run `fly tokens create deploy` and copy the token.
+2. Add it to your repo's secrets as `FLY_API_TOKEN` (Settings → Secrets and variables → Actions).
+3. Push to `main`.
+
+### Other platforms
+
+The included `Dockerfile` works on any container host — Railway, Render, DigitalOcean, a VPS, etc. The bot needs three env vars: `DISCORD_CLIENT_ID`, `DISCORD_TOKEN`, `DATABASE_URL` (Postgres).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:17
+    restart: unless-stopped
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: letterboxd_bot
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dev -d letterboxd_bot"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:

--- a/fly.toml
+++ b/fly.toml
@@ -1,8 +1,16 @@
-app = "letterboxd-discord-bot"
-primary_region = "ord"
+# fly.toml app configuration file
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+# This bot is a worker (Discord gateway + cron loop). It does not serve HTTP,
+# so there is no [http_service] block — that would let Fly auto-stop the VM
+# when no traffic arrives. The machine should stay running 24/7.
+
+app = 'letterboxd-discord-bot'
+primary_region = 'ord'
 
 [build]
 
 [[vm]]
-  size = "shared-cpu-1x"
-  memory = "512mb"
+  size = 'shared-cpu-1x'
+  memory = '512mb'

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,8 @@
+app = "letterboxd-discord-bot"
+primary_region = "ord"
+
+[build]
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 	},
 	"scripts": {
 		"start": "yarn prisma migrate deploy && yarn db:generate && NODE_PATH=./ ts-node src/app.ts",
+		"up": "docker compose up -d --wait && yarn db:migrate && yarn dev",
 		"dev": "NODE_PATH=./ nodemon --watch \"src/**/*\" --ext ts --exec \"ts-node src/app.ts\"",
 		"deploy-commands": "NODE_PATH=./ ts-node src/tools/deploy-commands.ts",
-		"deploy-heroku": "git push heroku main && heroku logs -t",
 		"test": "ts-node test.ts",
 		"db:migrate": "prisma migrate dev",
 		"db:generate": "prisma generate"


### PR DESCRIPTION
## Summary

- Move hosting from Heroku to Fly.io (worker machine) with Neon for Postgres.
- Add a `Dockerfile` so the bot is deploy-anywhere — Fly, Railway, Render, VPS, etc.
- Add `docker-compose.yml` for one-command local dev (`yarn up`).
- Add `.github/workflows/deploy.yml` so pushes to `main` auto-deploy to Fly.

## Why

Heroku is winding down for hobby projects and got pricey. This keeps the bot cheap (~$2-3/mo Fly + free-tier Neon) and keeps the project portable for anyone who forks it.

## What changed

- **New:** `Dockerfile`, `.dockerignore`, `fly.toml` (worker mode — no `[http_service]` so Fly doesn't auto-stop the VM), `docker-compose.yml`, `.github/workflows/deploy.yml`
- **Removed:** `Procfile`, `deploy-heroku` yarn script, Heroku/Node-18 references in docs
- **Local dev:** `yarn up` brings up Postgres (port 5433 to avoid clashes with a local install), applies migrations, runs the bot with hot reload
- **Docs:** README has a Fly + Neon walkthrough; CLAUDE.md updated

## Cutover (already done on `main` infra)

- [x] Neon project created, PG17, Heroku Postgres dumped + restored (867 users / 104 guilds — counts match source)
- [x] Fly app deployed in `ord`, secrets set, machine running on paid tier
- [x] Heroku worker scaled to 0; prod bot now serving from Fly + Neon
- [x] Bot verified online in real Discord servers; cron iterating prod guilds, RSS fetches running

## Test plan (post-merge)

- [x] Add `FLY_API_TOKEN` repo secret (`fly tokens create deploy` → paste into GitHub Settings → Secrets → Actions)
- [x] Merge this PR; confirm GH Action runs `flyctl deploy` and machine rolls
- [ ] After 24-48h of stable operation: `heroku apps:destroy letterboxd-discordbot`